### PR TITLE
fix(notes): Fix release notes

### DIFF
--- a/release_notes/2.17.1.md
+++ b/release_notes/2.17.1.md
@@ -1,1 +1,0 @@
-* Added 'use_event_id_sdi' parameter to asset config to allow updated event ingestion into the original container

--- a/release_notes/2.19.0.md
+++ b/release_notes/2.19.0.md
@@ -1,1 +1,0 @@
-* Added parameter in run query action to optionally remove the "_raw" field [PAPP-26864]

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+* Added 'use_event_id_sdi' parameter to asset config to allow updated event ingestion into the original container
+* Added parameter in run query action to optionally remove the "_raw" field [PAPP-26864]


### PR DESCRIPTION
There were two different feature PRs in this repo that got merged today, and it confused the release note generation. Fixing it manually