### PR TITLE
fix: run playbooks when ingesting new containers

### DIFF
--- a/release_notes/3.0.1.md
+++ b/release_notes/3.0.1.md
@@ -1,0 +1,1 @@
+* Improved Splunk authentication error handling during connectivity checks.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,2 @@
 **Unreleased**
-
-* Improved Splunk authentication error handling during connectivity checks.
+* Fixed the issue where playbooks were not executing when the app was ingesting new containers

--- a/src/actions/on_poll.py
+++ b/src/actions/on_poll.py
@@ -211,6 +211,7 @@ def on_poll(
                 source_data_identifier=sdi,
                 severity=severity,
                 start_time=spl_event_start,
+                run_automation=True,
             )
 
             if count == asset.container_update_state and not is_poll_now:


### PR DESCRIPTION
### Bug Fixes

* Fixed an issue where playbooks were not executed when the Splunk connector ingested new containers and created artifacts.
* Updated the ingestion workflow to ensure playbooks are triggered for newly ingested containers as expected.

### Manual Documentation

* [x] I have verified that manual documentation has been updated where appropriate

### Other information

* Fixes #81
* This change addresses the issue reported in #81 where playbooks were not being triggered during container ingestion.
* No new actions, authentication methods, REST handlers, or configuration parameters were added.
* Existing functionality is unchanged aside from restoring expected playbook execution behavior for newly ingested containers.
